### PR TITLE
Create custom employee view module

### DIFF
--- a/hr_employee_tree_extra/__init__.py
+++ b/hr_employee_tree_extra/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/hr_employee_tree_extra/__manifest__.py
+++ b/hr_employee_tree_extra/__manifest__.py
@@ -1,0 +1,19 @@
+{
+	'name': 'HR Employee Tree Extra',
+	'Version': '18.0.1.0.0',
+	'summary': 'Adds extra fields to the Employee tree view.',
+	'description': 'Inherits the standard hr.employee tree view and adds mobile_phone, birthday, identification_id. Includes minimal model and access rules.',
+	'author': 'Your Company',
+	'category': 'Human Resources',
+	'website': 'https://example.com',
+	'license': 'LGPL-3',
+	'depends': ['hr'],
+	'data': [
+		'security/ir.model.access.csv',
+		'security/hr_employee_rules.xml',
+		'views/hr_employee_views.xml',
+	],
+	'installable': True,
+	'application': False,
+	'auto_install': False,
+}

--- a/hr_employee_tree_extra/models/__init__.py
+++ b/hr_employee_tree_extra/models/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_employee

--- a/hr_employee_tree_extra/models/hr_employee.py
+++ b/hr_employee_tree_extra/models/hr_employee.py
@@ -1,0 +1,9 @@
+from odoo import models, fields
+
+
+class HrEmployee(models.Model):
+	_inherit = 'hr.employee'
+
+	mobile_phone = fields.Char(string='Mobile Phone')
+	birthday = fields.Date(string='Birthday')
+	identification_id = fields.Char(string='Identification No.')

--- a/hr_employee_tree_extra/security/hr_employee_rules.xml
+++ b/hr_employee_tree_extra/security/hr_employee_rules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+	<record id="hr_employee_rule_hr_user_all" model="ir.rule">
+		<field name="name">HR Users see all Employees</field>
+		<field name="model_id" ref="hr.model_hr_employee"/>
+		<field name="groups" eval="[(4, ref('hr.group_hr_user'))]"/>
+		<field name="domain_force">[(1,'=',1)]</field>
+	</record>
+</odoo>

--- a/hr_employee_tree_extra/security/ir.model.access.csv
+++ b/hr_employee_tree_extra/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_hr_employee_read_user,access.hr.employee.read.user,model_hr_employee,hr.group_hr_user,1,0,0,0

--- a/hr_employee_tree_extra/views/hr_employee_views.xml
+++ b/hr_employee_tree_extra/views/hr_employee_views.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+	<record id="hr_employee_tree_extra_inherit" model="ir.ui.view">
+		<field name="name">hr.employee.tree.extra.fields</field>
+		<field name="model">hr.employee</field>
+		<field name="inherit_id" ref="hr.hr_employee_view_tree"/>
+		<field name="arch" type="xml">
+			<xpath expr="//tree" position="inside">
+				<field name="mobile_phone"/>
+				<field name="birthday"/>
+				<field name="identification_id"/>
+			</xpath>
+		</field>
+	</record>
+</odoo>


### PR DESCRIPTION
Add custom module `hr_employee_tree_extra` to extend the `hr.employee` tree view with additional fields and ensure HR user visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1d11f2f-c00f-45f2-a00c-a8e66517afa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1d11f2f-c00f-45f2-a00c-a8e66517afa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

