### PR TITLE
Fix missing hr employee view external id

### DIFF
--- a/hr_employee_tree_extra/views/hr_employee_views.xml
+++ b/hr_employee_tree_extra/views/hr_employee_views.xml
@@ -3,7 +3,7 @@
 	<record id="hr_employee_tree_extra_inherit" model="ir.ui.view">
 		<field name="name">hr.employee.tree.extra.fields</field>
 		<field name="model">hr.employee</field>
-		<field name="inherit_id" ref="hr.hr_employee_view_tree"/>
+		<field name="inherit_id" ref="hr.view_employee_tree"/>
 		<field name="arch" type="xml">
 			<xpath expr="//tree" position="inside">
 				<field name="mobile_phone"/>


### PR DESCRIPTION
Fixes `External ID not found` error by updating the `inherit_id` reference to `hr.view_employee_tree` in `hr_employee_views.xml` for Odoo 18 compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d1519b5-75a2-478c-ba30-2154580ba3b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d1519b5-75a2-478c-ba30-2154580ba3b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

